### PR TITLE
Don't use caching of sprite list

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -465,12 +465,12 @@ paint_struct paint_session_arrange(paint_session * session)
             }
         } while (++quadrantIndex <= session->QuadrantFrontIndex);
 
-        paint_struct * ps_cache = paint_arrange_structs_helper(&psHead, session->QuadrantBackIndex & 0xFFFF, PAINT_QUADRANT_FLAG_NEXT, rotation);
+        [[maybe_unused]] paint_struct * ps_cache = paint_arrange_structs_helper(&psHead, session->QuadrantBackIndex & 0xFFFF, PAINT_QUADRANT_FLAG_NEXT, rotation);
 
         quadrantIndex = session->QuadrantBackIndex;
         while (++quadrantIndex < session->QuadrantFrontIndex)
         {
-            ps_cache = paint_arrange_structs_helper(ps_cache, quadrantIndex & 0xFFFF, 0, rotation);
+            ps_cache = paint_arrange_structs_helper(&psHead, quadrantIndex & 0xFFFF, 0, rotation);
         }
     }
 


### PR DESCRIPTION
Park taken from the to-be title sequence:

[b2.sv6.txt](https://github.com/ZehMatt/OpenRCT2/files/1627594/b2.sv6.txt)

You can see it exhibits the flicker a lot, both with and without caching.